### PR TITLE
Remove useless version tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 dist: bionic
 language: python
 python:
-  - "3.8"
-  - "3.7"
   - "3.6"
   - "3.5"
   


### PR DESCRIPTION
Fixes #55 

## What was changed in this PR:
 * Removed incompatible python version
 
## Why that was changed:
 * Toga can't run on these versions of python, so leaving them in our tests was a waste

## Description of changes made to each file:
 * .travis.yml - Removed "3.7" and "3.8" fields under python versions