### PR TITLE
Getting toga to install on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 
 before_install:
   - sudo apt-get update
-  - sudo apt-get -y install gobject-introspection-1.0
+  - sudo apt-get -y install gobject-introspection
 
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 before_install:
   - sudo apt-get update
   - sudo apt-get -y install gobject-introspection
+  - sudo apt-get -y install libgirepository1.0-dev
 
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ python:
   - "3.5"
 
 before_install:
-  - sudo apt-get install gobject-introspection-1.0
+  - sudo apt-get update
+  - sudo apt-get -y install gobject-introspection-1.0
 
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ language: python
 python:
   - "3.6"
   - "3.5"
-  
+
+before_install:
+  - sudo apt-get install gobject-introspection-1.0
+
 # command to install dependencies
 install:
   - pip install -e .

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -5,7 +5,7 @@
 ### Laptop convert to Linux
 * https://www.ifixit.com/Guide/How+to+convert+a+generic+Chromebook+to+Linux+OS/108259
 
-### Install all requirements on dev laptops
+### Set up repo on dev laptops
 * Create a [virtual environment](https://www.jetbrains.com/help/pycharm/creating-virtual-environment.html)
   * Open pycharm
   * `ctrl + alt + s` to open settings
@@ -22,3 +22,7 @@
 * Install requirements
   * open requirements.txt
   * click `install requirements`
+* Install modules
+  * open the terminal in pycharm
+  * cd into trackmanagementsystem
+  * enter `pip install -e .`

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ python-dateutil==2.8.0
 requests==2.22.0
 s3transfer==0.2.1
 six==1.13.0
+toga==0.3.0.dev18
 urllib3==1.25.7
 voc==0.1.6
 whichcraft==0.6.1

--- a/trackmanagementsystem/trackmanagementsystem/app.py
+++ b/trackmanagementsystem/trackmanagementsystem/app.py
@@ -1,27 +1,20 @@
-"""
-Gather Store and Track driver data, and win loss records
-"""
 import toga
-from toga.style import Pack
-from toga.style.pack import COLUMN, ROW
 
 
-class TrackManagementSystem(toga.App):
+def button_handler(widget):
+    print("hello")
 
-    def startup(self):
-        """
-        Construct and show the Toga application.
 
-        Usually, you would add your application to a main content box.
-        We then create a main window (with a name matching the app), and
-        show the main window.
-        """
-        main_box = toga.Box()
+def build(app):
+    box = toga.Box()
 
-        self.main_window = toga.MainWindow(title=self.name)
-        self.main_window.content = main_box
-        self.main_window.show()
+    button = toga.Button('Hello world', on_press=button_handler)
+    button.style.padding = 50
+    button.style.flex = 1
+    box.add(button)
+
+    return box
 
 
 def main():
-    return TrackManagementSystem('Track Management System', 'com.projectcodename.tms.trackmanagementsystem')
+    return toga.App('First App', 'org.beeware.helloworld', startup=build)


### PR DESCRIPTION
Fixes #18 

## What was changed in this PR:
 * Adding toga to the requirements and making it so that travis can use toga
 
## Why that was changed:
 * Need toga in order to run the actual program later, and travis to test the program later

## Description of changes made to each file:
 * .travis.yml : we need these things(`gobject-introspection` & `libgirepository1.0-dev`) to build toga apparently
 * docs/user_manual.md : adding information on installing our own package
 * requirements.txt : adding toga
 * trackmanagementsystem/trackmanagementsystem/app.py : copypasted from [here](https://toga.readthedocs.io/en/latest/tutorial/tutorial-0.html)